### PR TITLE
Handle pre-invite logic

### DIFF
--- a/src/app/PublicApp.js
+++ b/src/app/PublicApp.js
@@ -44,8 +44,8 @@ const PublicApp = ({ onLogin }) => {
                         />
                         <Route path="/forgot-username" component={ForgotUsernameContainer} />
                         <Route
-                            path="/invite/:selector/:token"
-                            render={({ history, match }) => <PreInviteContainer />}
+                            path="/pre-invite/:selector/:token"
+                            render={({ history, match }) => <PreInviteContainer history={history} match={match} />}
                         />
                         <Route render={({ history }) => <LoginContainer history={history} onLogin={onLogin} />} />
                     </Switch>

--- a/src/app/PublicApp.js
+++ b/src/app/PublicApp.js
@@ -9,6 +9,7 @@ import LoginContainer from './containers/LoginContainer';
 import ResetPasswordContainer from './containers/ResetPasswordContainer';
 import ForgotUsernameContainer from './containers/ForgotUsernameContainer';
 import RedeemContainer from './containers/RedeemContainer';
+import PreInviteContainer from './containers/PreInviteContainer';
 
 const PublicApp = ({ onLogin }) => {
     const [loading, setLoading] = useState(true);
@@ -42,6 +43,10 @@ const PublicApp = ({ onLogin }) => {
                             render={({ history }) => <ResetPasswordContainer history={history} onLogin={onLogin} />}
                         />
                         <Route path="/forgot-username" component={ForgotUsernameContainer} />
+                        <Route
+                            path="/invite/:selector/:token"
+                            render={({ history, match }) => <PreInviteContainer />}
+                        />
                         <Route render={({ history }) => <LoginContainer history={history} onLogin={onLogin} />} />
                     </Switch>
                 </Router>

--- a/src/app/containers/PreInviteContainer.js
+++ b/src/app/containers/PreInviteContainer.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Loader, useApi, useNotifications } from 'react-components';
+import { checkInvitation } from 'proton-shared/lib/api/invites';
+import { INVITE_TYPES } from 'proton-shared/lib/constants';
+import { c } from 'ttag';
+
+import SignInLayout from '../components/layout/SignInLayout';
+
+const { VPN } = INVITE_TYPES;
+
+const PreInviteContainer = ({ history, match }) => {
+    const { createNotification } = useNotifications();
+    const { token, selector } = match.params;
+    const api = useApi();
+
+    const invalid = () => {
+        createNotification({ text: c('Error').t`Invalid invitation link`, type: 'error' });
+        history.push('/login');
+    };
+
+    if (!token || !selector) {
+        return invalid();
+    }
+
+    api(checkInvitation({ Selector: selector, Token: token, Type: VPN }))
+        .then(({ Valid }) => {
+            if (!Valid) {
+                return invalid();
+            }
+
+            history.push({
+                pathname: '/signup',
+                state: { selector, token }
+            });
+        })
+        .catch(() => {
+            invalid();
+        });
+
+    return (
+        <SignInLayout title={c('Title').t`Checking invitation parameters`}>
+            <Loader />
+        </SignInLayout>
+    );
+};
+
+PreInviteContainer.propTypes = {
+    history: PropTypes.object.isRequired,
+    match: PropTypes.object.isRequired
+};
+
+export default PreInviteContainer;

--- a/src/app/containers/PreInviteContainer.js
+++ b/src/app/containers/PreInviteContainer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Loader, useApi, useNotifications } from 'react-components';
 import { checkInvitation } from 'proton-shared/lib/api/invites';
@@ -19,24 +19,26 @@ const PreInviteContainer = ({ history, match }) => {
         history.push('/login');
     };
 
-    if (!token || !selector) {
-        return invalid();
-    }
+    useEffect(() => {
+        if (!token || !selector) {
+            return invalid();
+        }
 
-    api(checkInvitation({ Selector: selector, Token: token, Type: VPN }))
-        .then(({ Valid }) => {
-            if (!Valid) {
-                return invalid();
-            }
+        api(checkInvitation({ Selector: selector, Token: token, Type: VPN }))
+            .then(({ Valid }) => {
+                if (!Valid) {
+                    return invalid();
+                }
 
-            history.push({
-                pathname: '/signup',
-                state: { selector, token }
+                history.push({
+                    pathname: '/signup',
+                    state: { selector, token }
+                });
+            })
+            .catch(() => {
+                invalid();
             });
-        })
-        .catch(() => {
-            invalid();
-        });
+    }, []);
 
     return (
         <SignInLayout title={c('Title').t`Checking invitation parameters`}>


### PR DESCRIPTION
![Capture d’écran 2019-08-28 à 17 27 21](https://user-images.githubusercontent.com/1345786/63869854-1e89f080-c9b9-11e9-8f76-7e79a7d84ed9.png)

Add new route: `/pre-invite/:selector/:token`.
- If **invalid**, redirect to `/login`
- If **valid**, redirect to `/signup` (state: `{ selector, token }`)