### PR TITLE
Fix login responsive

### DIFF
--- a/src/app/components/layout/SignInLayout.js
+++ b/src/app/components/layout/SignInLayout.js
@@ -25,8 +25,9 @@ const SignInLayout = ({ children, title }) => {
                     <VpnLogo className="fill-primary" />
                 </div>
                 <div className="nomobile flex-item-fluid alignright">
-                    <SupportDropdown className="mr1 pv-button-greenborder-dark" />
-                    <Link className="pm-button--primary" to="/signup">{c('Link').t`Sign up for free`}</Link>
+                    <SupportDropdown className="pv-button-greenborder-dark" />
+                    <Link className="ml1 notablet pm-button--primary" to="/signup">{c('Link')
+                        .t`Sign up for free`}</Link>
                 </div>
             </header>
             <Title className="flex-item-noshrink aligncenter color-primary">{title}</Title>


### PR DESCRIPTION
As the top button "sign up for free" is the same as the link below (and creating issues around 700px width viewport), I've hidden it on tablets.
![image](https://user-images.githubusercontent.com/2578321/64115691-9167e280-cd90-11e9-9c63-0bc53db0cf72.png)

- added `notablet` helper, moved margin to hidden element on tablets

Fix applied: 
![image](https://user-images.githubusercontent.com/2578321/64115601-58c80900-cd90-11e9-80ff-4a257d471ae9.png)
