### PR TITLE
Redirect to account step when bestdeal cookie and planName is set

### DIFF
--- a/src/app/containers/SignupContainer/SignupContainer.js
+++ b/src/app/containers/SignupContainer/SignupContainer.js
@@ -29,13 +29,10 @@ const SignupContainer = ({ history, onLogin, stopRedirect }) => {
     }, []);
 
     const searchParams = new URLSearchParams(history.location.search);
-    const hasOffer = checkCookie('offer', 'bestdeal');
     const preSelectedPlan = searchParams.get('plan');
-    const availablePlans = hasOffer ? BEST_DEAL_PLANS : VPN_PLANS;
+    const availablePlans = checkCookie('offer', 'bestdeal') ? BEST_DEAL_PLANS : VPN_PLANS;
 
-    const [signupState, setSignupState] = useState(
-        hasOffer && preSelectedPlan ? SignupState.Account : SignupState.Plan
-    );
+    const [signupState, setSignupState] = useState(preSelectedPlan ? SignupState.Account : SignupState.Plan);
     const [upsellDone, setUpsellDone] = useState(false);
     const [loading, withLoading] = useLoading(false);
     const historyState = history.location.state || {};

--- a/src/app/containers/SignupContainer/SignupContainer.js
+++ b/src/app/containers/SignupContainer/SignupContainer.js
@@ -7,12 +7,13 @@ import useSignup from './useSignup';
 import { c } from 'ttag';
 import VerificationStep from './VerificationStep/VerificationStep';
 import PaymentStep from './PaymentStep/PaymentStep';
-import { PLAN, VPN_PLANS } from './plans';
+import { PLAN, VPN_PLANS, BEST_DEAL_PLANS } from './plans';
 import SupportDropdown from '../../components/header/SupportDropdown';
 import { CYCLE } from 'proton-shared/lib/constants';
 import PlanDetails from './SelectedPlan/PlanDetails';
 import PlanUpsell from './SelectedPlan/PlanUpsell';
 import useVerification from './VerificationStep/useVerification';
+import { checkCookie } from 'proton-shared/lib/helpers/cookies';
 
 const SignupState = {
     Plan: 'plan',
@@ -28,7 +29,13 @@ const SignupContainer = ({ history, onLogin, stopRedirect }) => {
     }, []);
 
     const searchParams = new URLSearchParams(history.location.search);
-    const [signupState, setSignupState] = useState(SignupState.Plan);
+    const hasOffer = checkCookie('offer', 'bestdeal');
+    const preSelectedPlan = searchParams.get('plan');
+    const availablePlans = hasOffer ? BEST_DEAL_PLANS : VPN_PLANS;
+
+    const [signupState, setSignupState] = useState(
+        hasOffer && preSelectedPlan ? SignupState.Account : SignupState.Plan
+    );
     const [upsellDone, setUpsellDone] = useState(false);
     const [loading, withLoading] = useLoading(false);
     const historyState = history.location.state || {};
@@ -52,11 +59,15 @@ const SignupContainer = ({ history, onLogin, stopRedirect }) => {
         isLoading,
         appliedCoupon,
         appliedInvite
-    } = useSignup(handleLogin, coupon, invite, {
-        planName: searchParams.get('plan'),
-        cycle: Number(searchParams.get('billing')),
-        currency: searchParams.get('currency')
-    });
+    } = useSignup(
+        handleLogin,
+        { coupon, invite, availablePlans },
+        {
+            planName: preSelectedPlan,
+            cycle: Number(searchParams.get('billing')),
+            currency: searchParams.get('currency')
+        }
+    );
     const { verify, requestCode } = useVerification();
 
     const handleSelectPlan = (model, next = false) => {
@@ -156,7 +167,7 @@ const SignupContainer = ({ history, onLogin, stopRedirect }) => {
                     <>
                         {signupState === SignupState.Plan && (
                             <PlanStep
-                                plans={VPN_PLANS.map((plan) => getPlanByName(plan))}
+                                plans={availablePlans.map((plan) => getPlanByName(plan))}
                                 model={model}
                                 onChangeCycle={(cycle) => setModel({ ...model, cycle })}
                                 onChangeCurrency={(currency) => setModel({ ...model, currency })}

--- a/src/app/containers/SignupContainer/plans.js
+++ b/src/app/containers/SignupContainer/plans.js
@@ -22,6 +22,7 @@ export const PLAN_NAMES = {
 };
 
 export const VPN_PLANS = [PLAN.FREE, PLAN.BASIC, PLAN.PLUS, PLAN.VISIONARY];
+export const BEST_DEAL_PLANS = [PLAN.BASIC, PLAN.PLUS, PLAN.VISIONARY];
 
 const getPlanFeatures = (plan, maxConnections, countries) =>
     ({


### PR DESCRIPTION
Related: https://github.com/ProtonMail/proton-shared/pull/50

Hides the free plan if bestdeal cookie is set.
Skips plan selection if `/signup?plan=PLAN` ~and cookie is set~.