### PR TITLE
Fix: #273 ~ Fix browser navigation in signup

### DIFF
--- a/src/app/PublicApp.js
+++ b/src/app/PublicApp.js
@@ -29,10 +29,14 @@ const PublicApp = ({ onLogin }) => {
                         render={({ history, match }) => <PreInviteContainer history={history} match={match} />}
                     />
                     <Route
-                        exact
-                        path="/signup"
-                        render={({ history }) => (
-                            <SignupContainer stopRedirect={stopRedirect} history={history} onLogin={onLogin} />
+                        path="/signup/:step?"
+                        render={({ history, match }) => (
+                            <SignupContainer
+                                stopRedirect={stopRedirect}
+                                history={history}
+                                match={match}
+                                onLogin={onLogin}
+                            />
                         )}
                     />
                     <Route

--- a/src/app/containers/SignupContainer/AccountStep/AccountForm.js
+++ b/src/app/containers/SignupContainer/AccountStep/AccountForm.js
@@ -16,12 +16,12 @@ import {
 import { c } from 'ttag';
 import { queryCheckUsernameAvailability } from 'proton-shared/lib/api/user';
 
-const AccountForm = ({ onSubmit }) => {
+const AccountForm = ({ model, onSubmit }) => {
     const api = useApi();
-    const [username, setUsername] = useState('');
-    const [password, setPassword] = useState('');
-    const [confirmPassword, setConfirmPassword] = useState('');
-    const [email, setEmail] = useState('');
+    const [username, setUsername] = useState(model.username);
+    const [password, setPassword] = useState(model.password);
+    const [confirmPassword, setConfirmPassword] = useState(model.password);
+    const [email, setEmail] = useState(model.email);
     const [usernameError, setUsernameError] = useState();
     const [loading, withLoading] = useLoading();
 
@@ -149,6 +149,7 @@ const AccountForm = ({ onSubmit }) => {
 };
 
 AccountForm.propTypes = {
+    model: PropTypes.object.isRequired,
     onSubmit: PropTypes.func.isRequired
 };
 

--- a/src/app/containers/SignupContainer/AccountStep/AccountStep.js
+++ b/src/app/containers/SignupContainer/AccountStep/AccountStep.js
@@ -24,7 +24,7 @@ const AccountStep = ({ onContinue, model, children }) => {
             <SubTitle>{c('Title').t`Create an account`}</SubTitle>
             <Row>
                 <div>
-                    <AccountForm onSubmit={handleSubmit} />
+                    <AccountForm model={model} onSubmit={handleSubmit} />
                     <LoginPanel />
                 </div>
                 {children}

--- a/src/app/containers/SignupContainer/SignupContainer.js
+++ b/src/app/containers/SignupContainer/SignupContainer.js
@@ -52,7 +52,7 @@ const SignupContainer = ({ match, history, onLogin, stopRedirect }) => {
 
     const handleLogin = (...args) => {
         if (redirectToMobile) {
-            goToStep(SignupState.MobileRedirection);
+            return goToStep(SignupState.MobileRedirection);
         }
 
         stopRedirect();

--- a/src/app/containers/SignupContainer/SignupContainer.js
+++ b/src/app/containers/SignupContainer/SignupContainer.js
@@ -16,7 +16,7 @@ import useVerification from './VerificationStep/useVerification';
 import { checkCookie } from 'proton-shared/lib/helpers/cookies';
 import MobileRedirectionStep from './MobileRedirectionStep/MobileRedirectionStep';
 
-export const SignupState = {
+const SignupState = {
     Plan: 'plan',
     Account: 'account',
     Verification: 'verification',
@@ -33,7 +33,7 @@ const SignupContainer = ({ match, history, onLogin, stopRedirect }) => {
 
     useEffect(() => {
         document.title = c('Title').t`Sign up - ProtonVPN`;
-        // Always start at plans of account if plan is preselected
+        // Always start at plans, or account if plan is preselected
         if (preSelectedPlan) {
             history.replace(`/signup/${SignupState.Account}`);
         } else {
@@ -48,9 +48,11 @@ const SignupContainer = ({ match, history, onLogin, stopRedirect }) => {
     const invite = historyState.invite;
     const coupon = historyState.coupon;
 
+    const goToStep = (step) => history.push(`/signup/${step}`);
+
     const handleLogin = (...args) => {
         if (redirectToMobile) {
-            return history.push(`/signup/${SignupState.MobileRedirection}`);
+            goToStep(SignupState.MobileRedirection);
         }
 
         stopRedirect();
@@ -79,10 +81,6 @@ const SignupContainer = ({ match, history, onLogin, stopRedirect }) => {
         }
     );
     const { verify, requestCode } = useVerification();
-
-    const goToStep = (step) => {
-        history.push(`/signup/${step}`);
-    };
 
     const handleSelectPlan = (model, next = false) => {
         setModel(model);
@@ -150,7 +148,7 @@ const SignupContainer = ({ match, history, onLogin, stopRedirect }) => {
                 <div className="flex flex-nowrap flex-items-center onmobile-flex-wrap mb1">
                     <div className="flex-item-fluid plan-back-button">
                         {!creatingAccount &&
-                            (match.params.step && match.params.step !== SignupState.Plan ? (
+                            (signupState && signupState !== SignupState.Plan ? (
                                 <Button onClick={() => history.goBack()}>{c('Action').t`Back`}</Button>
                             ) : (
                                 <Href className="pm-button" url="https://protonvpn.com" target="_self">{c('Action')
@@ -176,7 +174,7 @@ const SignupContainer = ({ match, history, onLogin, stopRedirect }) => {
                     </div>
                 ) : (
                     <>
-                        {(!match.params.step || match.params.step === SignupState.Plan) && (
+                        {(!signupState || signupState === SignupState.Plan) && (
                             <PlanStep
                                 plans={availablePlans.map((plan) => getPlanByName(plan))}
                                 model={model}
@@ -186,12 +184,12 @@ const SignupContainer = ({ match, history, onLogin, stopRedirect }) => {
                                 onSelectPlan={handleSelectPlan}
                             />
                         )}
-                        {match.params.step === SignupState.Account && (
+                        {signupState === SignupState.Account && (
                             <AccountStep model={model} onContinue={handleCreateAccount}>
                                 {selectedPlanComponent}
                             </AccountStep>
                         )}
-                        {match.params.step === SignupState.Verification && (
+                        {signupState === SignupState.Verification && (
                             <VerificationStep
                                 model={model}
                                 allowedMethods={signupAvailability.allowedMethods}
@@ -201,7 +199,7 @@ const SignupContainer = ({ match, history, onLogin, stopRedirect }) => {
                                 {selectedPlanComponent}
                             </VerificationStep>
                         )}
-                        {match.params.step === SignupState.Payment && (
+                        {signupState === SignupState.Payment && (
                             <PaymentStep
                                 model={model}
                                 paymentAmount={selectedPlan.price.total}
@@ -210,7 +208,7 @@ const SignupContainer = ({ match, history, onLogin, stopRedirect }) => {
                                 {selectedPlanComponent}
                             </PaymentStep>
                         )}
-                        {match.params.step === SignupState.MobileRedirection && <MobileRedirectionStep model={model} />}
+                        {signupState === SignupState.MobileRedirection && <MobileRedirectionStep model={model} />}
                     </>
                 )}
             </div>
@@ -221,6 +219,11 @@ const SignupContainer = ({ match, history, onLogin, stopRedirect }) => {
 SignupContainer.propTypes = {
     stopRedirect: PropTypes.func.isRequired,
     onLogin: PropTypes.func.isRequired,
+    match: PropTypes.shape({
+        params: PropTypes.shape({
+            step: PropTypes.string
+        })
+    }).isRequired,
     history: PropTypes.shape({
         push: PropTypes.func.isRequired,
         location: PropTypes.shape({


### PR DESCRIPTION
Fixes: #273 

Added step param to signup instead of local state.

Always redirects to `/signup` when visiting sub-routes like `/signup/account` in order to prevent skipping steps.

Browser back now navigates between steps.