### PR TITLE
Fix #280 ~ don't clear payment form on cancel payment

### DIFF
--- a/src/app/containers/SignupContainer/SignupContainer.js
+++ b/src/app/containers/SignupContainer/SignupContainer.js
@@ -99,7 +99,7 @@ const SignupContainer = ({ history, onLogin, stopRedirect }) => {
 
     const handlePayment = async (model, paymentParameters) => {
         const paymentDetails = await makePayment(model, paymentParameters);
-        await signup(model, { paymentDetails });
+        await withCreateLoading(signup(model, { paymentDetails }));
         setModel(model);
     };
 
@@ -201,11 +201,7 @@ const SignupContainer = ({ history, onLogin, stopRedirect }) => {
                         )}
 
                         {signupState === SignupState.Payment && (
-                            <PaymentStep
-                                model={model}
-                                paymentAmount={selectedPlan.price.total}
-                                onPay={(...rest) => withCreateLoading(handlePayment(...rest))}
-                            >
+                            <PaymentStep model={model} paymentAmount={selectedPlan.price.total} onPay={handlePayment}>
                                 {selectedPlanComponent}
                             </PaymentStep>
                         )}


### PR DESCRIPTION
Moved loading to when user is actually being created, so there is no weird redirect happening during payment.

This loading used to be on the whole function because PayPal didn't have a loading state, but now it does, so it's k.