### PR TITLE
Don't save paypal-credit during signup

### DIFF
--- a/src/app/containers/SignupContainer/SignupContainer.js
+++ b/src/app/containers/SignupContainer/SignupContainer.js
@@ -104,9 +104,11 @@ const SignupContainer = ({ match, history, onLogin, stopRedirect }) => {
         setModel(model);
     };
 
-    const handlePayment = async (model, paymentParameters) => {
+    const handlePayment = async (model, paymentParameters = {}) => {
         const paymentDetails = await makePayment(model, paymentParameters);
-        await withCreateLoading(signup(model, { paymentDetails }));
+        const { Payment = {} } = paymentParameters;
+        const { Type = '' } = Payment;
+        await withCreateLoading(signup(model, { paymentDetails, paymentMethodType: Type }));
         setModel(model);
     };
 

--- a/src/app/containers/SignupContainer/useSignup.js
+++ b/src/app/containers/SignupContainer/useSignup.js
@@ -16,7 +16,14 @@ import { subscribe, setPaymentMethod, verifyPayment, checkSubscription } from 'p
 import { mergeHeaders } from 'proton-shared/lib/fetch/helpers';
 import { getAuthHeaders } from 'proton-shared/lib/api';
 import { getRandomString } from 'proton-shared/lib/helpers/string';
-import { DEFAULT_CURRENCY, CYCLE, PLAN_TYPES, TOKEN_TYPES, CURRENCIES } from 'proton-shared/lib/constants';
+import {
+    DEFAULT_CURRENCY,
+    CYCLE,
+    PLAN_TYPES,
+    TOKEN_TYPES,
+    CURRENCIES,
+    PAYMENT_METHOD_TYPES
+} from 'proton-shared/lib/constants';
 import { getPlan, PLAN, VPN_PLANS } from './plans';
 import { c } from 'ttag';
 
@@ -220,7 +227,10 @@ const useSignup = (onLogin, { coupon, invite, availablePlans = VPN_PLANS } = {},
         }
 
         // Add payment method
-        if (signupToken.paymentDetails) {
+        if (
+            signupToken.paymentDetails &&
+            [PAYMENT_METHOD_TYPES.CARD, PAYMENT_METHOD_TYPES.PAYPAL].includes(signupToken.paymentMethodType)
+        ) {
             await api(withAuthHeaders(UID, AccessToken, setPaymentMethod(signupToken.paymentDetails.Payment)));
         }
 


### PR DESCRIPTION
Only save `card` and `paypal` during signup as payment method.

Fix https://gitlab.protontech.ch/ProtonVPN/web/protonvpn-settings/issues/16
PR related: https://github.com/ProtonMail/react-components/pull/328