### PR TITLE
Fix - alignment of icon/text of support drop down

### DIFF
--- a/src/app/containers/SignupContainer/SignupContainer.js
+++ b/src/app/containers/SignupContainer/SignupContainer.js
@@ -182,7 +182,7 @@ const SignupContainer = ({ match, history, onLogin, stopRedirect }) => {
                             </Href>
                         </div>
                         <div className="flex-item-fluid alignright plan-help-button">
-                            <SupportDropdown content={c('Action').t`Need help`} />
+                            <SupportDropdown className="inline-flex" content={c('Action').t`Need help`} />
                         </div>
                     </div>
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/2578321/67968416-9ec21180-fc07-11e9-89b5-c5cc5adc219d.png)

After:
![image](https://user-images.githubusercontent.com/2578321/67968430-a71a4c80-fc07-11e9-9c5c-116ebee4fa22.png)

- just added a class `inline-flex` on support drop down