### PR TITLE
Use `size` property instead of className to specify modal size

### DIFF
--- a/src/app/containers/SignupContainer/PlanStep/PlanComparisonModal.js
+++ b/src/app/containers/SignupContainer/PlanStep/PlanComparisonModal.js
@@ -14,7 +14,7 @@ const PlanComparisonModal = ({ modalTitleID = 'modalTitle', onClose, defaultCycl
     const [plans, loadingPlans] = usePlans();
 
     return (
-        <DialogModal onClose={onClose} className="pm-modal--wider" {...rest}>
+        <DialogModal onClose={onClose} size="wide" {...rest}>
             <HeaderModal hasClose modalTitleID={modalTitleID} onClose={onClose}>
                 {c('Title').t`ProtonVPN plan comparison`}
             </HeaderModal>


### PR DESCRIPTION
Requires https://gitlab.protontech.ch/ProtonVPN/web/protonvpn-settings/issues/65 to be closed